### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,3 +30,4 @@ dependencies:
       - git+https://github.com/hCoV-2019/pangolin.git
       - git+https://github.com/cov-lineages/pangoLEARN.git
       - git+https://github.com/cov-ert/datafunk.git
+      - git+https://github.com/jts/ncov-tools.git#egg=ncov_parser&subdirectory=parser


### PR DESCRIPTION
Found out that `pip` can install from subdirectories of a repo. This change means that a conda environment can be build automatically without activating the environment and installing `parser` by hand. This will make packaging for workflows/conda/containers easier/less manual.